### PR TITLE
Minor revisions

### DIFF
--- a/examples/toy_problem/echo.py
+++ b/examples/toy_problem/echo.py
@@ -61,7 +61,7 @@ def create_initial_state():
 
 if platform.node().endswith((".scicore.unibas.ch", ".cluster.bc2.ch")):
     my_environment = environments.BaselSlurmEnvironment(
-        batch_size=2, enforce_order=True)
+        batch_size=2, allow_nondeterministic_successor_choice=True)
 else:
     my_environment = environments.LocalEnvironment()
 

--- a/examples/toy_problem/echo.py
+++ b/examples/toy_problem/echo.py
@@ -61,7 +61,7 @@ def create_initial_state():
 
 if platform.node().endswith((".scicore.unibas.ch", ".cluster.bc2.ch")):
     my_environment = environments.BaselSlurmEnvironment(
-        batch_size=2, enforce_order=False)
+        batch_size=2, enforce_order=True)
 else:
     my_environment = environments.LocalEnvironment()
 

--- a/examples/toy_problem/grid_test.py
+++ b/examples/toy_problem/grid_test.py
@@ -108,6 +108,6 @@ search_result = main(create_initial_state(),
                      MyGenerator,
                      MyEvaluator,
                      my_environment,
-                     enforce_order=False)
+                     allow_nondeterministic_successor_choice=False)
 
 print(f"Search result:\n{pprint.pformat(search_result)}")

--- a/examples/toy_problem/grid_test.py
+++ b/examples/toy_problem/grid_test.py
@@ -108,6 +108,6 @@ search_result = main(create_initial_state(),
                      MyGenerator,
                      MyEvaluator,
                      my_environment,
-                     enforce_order=True)
+                     enforce_order=False)
 
 print(f"Search result:\n{pprint.pformat(search_result)}")

--- a/minimizer/grid/environments.py
+++ b/minimizer/grid/environments.py
@@ -24,6 +24,15 @@ DONE_STATE = {"COMPLETED"}
 BUSY_STATES = {"PENDING", "RUNNING", "REQUEUED", "SUSPENDED"}
 
 
+"""
+When performing the search on a Slurm grid, the possibility of
+failure at some point is increased due to the introduced parallelism
+on multiple nodes and an I/O load over the network filesystem. When
+setting *allow_nondeterministic_successor_choice* to ``False``, the
+:func:`search <minimizer.search.search>` function will enforce that
+the search is aborted if a single task fails and no successor from
+an earlier task is accepted.
+"""
 class Environment:
     def __init__(self, allow_nondeterministic_successor_choice,
                  batch_size=1):

--- a/minimizer/grid/environments.py
+++ b/minimizer/grid/environments.py
@@ -173,8 +173,7 @@ class SlurmEnvironment(Environment):
         for task in self.job["tasks"]:
             result_file = os.path.join(task["dir"], "result")
             if self.wait_for_filesystem(result_file):
-                result = st.parse_result(result_file)
-                if result:
+                if st.parse_exit_code(result_file) == 0:
                     logging.info("Found successor!")
                     successor = task["state"]
                     break

--- a/minimizer/grid/environments.py
+++ b/minimizer/grid/environments.py
@@ -183,7 +183,7 @@ class SlurmEnvironment(Environment):
 
         successor = None
         for task in self.job["tasks"]:
-            result_file = os.path.join(task["dir"], "result")
+            result_file = os.path.join(task["dir"], "exit_code")
             if self.wait_for_filesystem(result_file):
                 if st.parse_exit_code(result_file) == 0:
                     logging.info("Found successor!")

--- a/minimizer/grid/slurm-array-job.template
+++ b/minimizer/grid/slurm-array-job.template
@@ -34,7 +34,7 @@ RUN_DIR=${RUN_DIRS[$SLURM_ARRAY_TASK_ID]}
 %(python)s %(script_path)s --evaluate "$RUN_DIR/dump"
 RETCODE=$?
 
-echo "The evaluation finished with exit code $RETCODE" > $RUN_DIR/result
+echo "$RETCODE" > $RUN_DIR/exit_code
 # redirect output of grid_test to dump directory
 ) > "$RUN_DIR/driver.log" 2> "$RUN_DIR/driver.err"
 

--- a/minimizer/grid/slurm_tools.py
+++ b/minimizer/grid/slurm_tools.py
@@ -21,10 +21,9 @@ def read_and_unpickle_state(file_path):
 
 
 def parse_result(result_file):
-    rf = open(result_file, "r")
-    match = re.match(
-        r"The evaluation finished with exit code (\d+)", rf.read())
-    rf.close()
+    with open(result_file, "r") as rf:
+        match = re.match(
+             r"The evaluation finished with exit code (\d+)", rf.read())
     exitcode = int(match.group(1))
     result = True if exitcode == 0 else False
     return result

--- a/minimizer/grid/slurm_tools.py
+++ b/minimizer/grid/slurm_tools.py
@@ -20,13 +20,10 @@ def read_and_unpickle_state(file_path):
         return pickle.load(dump_file)
 
 
-def parse_result(result_file):
+def parse_exit_code(result_file):
     with open(result_file, "r") as rf:
-        match = re.match(
-             r"The evaluation finished with exit code (\d+)", rf.read())
-    exitcode = int(match.group(1))
-    result = True if exitcode == 0 else False
-    return result
+        exitcode = int(rf.read())
+    return exitcode
 
 
 def fill_template(**parameters):

--- a/minimizer/main.py
+++ b/minimizer/main.py
@@ -102,4 +102,4 @@ def _random_sleep():
     """Sleep for 1-5 seconds, chosen at random."""
     import random
     import time
-    time.sleep(random.randint(1, 5))
+    time.sleep(1 + 4 * random.random())

--- a/minimizer/main.py
+++ b/minimizer/main.py
@@ -26,35 +26,30 @@ def main(
 ):
     """Start a minimizer search and return the resulting state.
 
-    The search is started from *initial_state*, which is a dictionary describing
-    the initial conditions of what you want to minimize.
+    The search is started from *initial_state*, which is a dictionary
+    describing the initial conditions of what you want to minimize.
     
-    *successor_generators* is
-    a single class name or a list of multiple ones whose implementation define(s)
-    how successors of a state are generated. When a list is given, the search is
-    performed serially with each of them, starting from the resulting state of the
-    search with the preceding successor generator. Successor generators must
-    implement the
-    :class:`SuccessorGenerator <minimizer.planning.generators.SuccessorGenerator>`
-    class.
+    *successor_generators* is a single class name or a list of multiple
+    ones whose implementation define(s) how successors of a state are
+    generated. When a list is given, the search is performed serially
+    with each of them, starting from the resulting state of the search
+    with the preceding successor generator. Successor generators must
+    implement the :class:`SuccessorGenerator
+    <minimizer.planning.generators.SuccessorGenerator>` class.
 
-    *evaluator* is the name of the class that was implemented to evaluate a state
-    during the search. Evaluator implementations must be derived from the
-    :class:`Evaluator <minimizer.evaluator.Evaluator>` class.
+    *evaluator* is the name of the class that was implemented to
+    evaluate a state during the search. Evaluator implementations must
+    be derived from the :class:`Evaluator
+    <minimizer.evaluator.Evaluator>` class.
 
-    *environment* determines whether the search should be done on a local machine
-    or on a Slurm computing grid. Use :class:`minimizer.grid.environments.LocalEnvironment`
-    or an implementation of :class:`minimizer.grid.environments.SlurmEnvironment`.
+    *environment* determines whether the search should be done on a
+    local machine or on a Slurm computing grid. Use
+    :class:`minimizer.grid.environments.LocalEnvironment` or an
+    implementation of
+    :class:`minimizer.grid.environments.SlurmEnvironment`.
 
-    When performing the search on a Slurm grid, the possibility of failure at some
-    point is increased due to the introduced parallelism on multiple nodes and an
-    I/O load over the network filesystem. When setting *enforce_order* to ``True``,
-    the :func:`search <minimizer.grid.search.search>` function will enforce that
-    the search is aborted if a single task fails and no successor from an earlier
-    task is accepted.
-
-    *batch-size* regulates how many successors at most are evaluated in parallel,
-    when executing the search on the grid.
+    *batch-size* regulates how many successors at most are evaluated in
+    parallel, when executing the search on the grid.
 
     Example of the main function in action:
 
@@ -80,7 +75,8 @@ def main(
             if os.path.exists(dump_file_path):
                 break
         else:
-            sys.exit(1)  # Make evaluation fail if state file is not found after 10 attempts.
+            # Make evaluation fail if state file is not found after 10 attempts.
+            sys.exit(1)
         state = st.read_and_unpickle_state(dump_file_path)
         state["cwd"] = os.path.dirname(dump_file_path)
         result = evaluator().evaluate(state)
@@ -90,8 +86,8 @@ def main(
     elif environment:
         current_state = initial_state
         for successor_generator in successor_generators:
-            current_state = search(
-                current_state, successor_generator(), evaluator, environment)
+            current_state = search(current_state, successor_generator(),
+                                   evaluator, environment)
         return current_state
 
     else:

--- a/minimizer/planning/pddl_writer.py
+++ b/minimizer/planning/pddl_writer.py
@@ -117,18 +117,17 @@ def write_domain_axioms(task, df):
 
 
 def write_domain_PDDL(task, domain_filename):
-    df = open(domain_filename, "w")
-    df.write("\n(")
-    write_domain_header(task, df)
-    write_domain_requirements(task, df)
-    write_domain_types(task, df)
-    write_domain_objects(task, df)
-    write_domain_predicates(task, df)
-    write_domain_functions(task, df)
-    write_domain_axioms(task, df)
-    write_domain_actions(task, df)
-    df.write(")\n")
-    df.close()
+    with open(domain_filename, "w") as df:
+        df.write("\n(")
+        write_domain_header(task, df)
+        write_domain_requirements(task, df)
+        write_domain_types(task, df)
+        write_domain_objects(task, df)
+        write_domain_predicates(task, df)
+        write_domain_functions(task, df)
+        write_domain_axioms(task, df)
+        write_domain_actions(task, df)
+        df.write(")\n")
 
 
 def write_problem_header(task, pf):
@@ -162,15 +161,14 @@ def write_problem_metric(task, pf):
 
 
 def write_problem_PDDL(task, problem_filename):
-    pf = open(problem_filename, "w")
-    pf.write("\n(")
-    write_problem_header(task, pf)
-    write_problem_domain(task, pf)
-    write_problem_init(task, pf)
-    write_problem_goal(task, pf)
-    write_problem_metric(task, pf)
-    pf.write(")\n")
-    pf.close()
+    with open(problem_filename, "w") as pf:
+        pf.write("\n(")
+        write_problem_header(task, pf)
+        write_problem_domain(task, pf)
+        write_problem_init(task, pf)
+        write_problem_goal(task, pf)
+        write_problem_metric(task, pf)
+        pf.write(")\n")
 
 
 def write_PDDL(task: Task, domain_filename: str, problem_filename: str):

--- a/minimizer/planning/sas_reader.py
+++ b/minimizer/planning/sas_reader.py
@@ -113,30 +113,30 @@ def read_axioms(sf, num_axioms):
 
 
 def sas_file_to_SASTask(sas_file) -> SASTask:
-    sf = open(sas_file, 'r')
-    while True:
-        # pos = sf.tell()
-        line = sf.readline().replace("\n", "")
-        if line == "begin_metric":
-            break
-    metric = bool(sf.readline().replace("\n", ""))
-    sf.readline()  # skip end_metric
-    # read variables
-    num_vars = int(sf.readline().replace("\n", ""))
-    variables = read_variables(sf, num_vars)
-    # read mutexes
-    num_mutexes = int(sf.readline().replace("\n", ""))
-    mutexes = read_mutexes(sf, num_mutexes)
-    # read init state
-    init = read_init_state(sf, num_vars)
-    # read goal
-    goal = read_goal(sf)
-    # read operators
-    num_operators = int(sf.readline().replace("\n", ""))
-    operators = read_operators(sf, num_operators)
-    # read axioms
-    num_axioms = int(sf.readline().replace("\n", ""))
-    axioms = read_axioms(sf, num_axioms)
+    with open(sas_file, "r") as sf:
+        while True:
+            # pos = sf.tell()
+            line = sf.readline().replace("\n", "")
+            if line == "begin_metric":
+                break
+        metric = bool(sf.readline().replace("\n", ""))
+        sf.readline()  # skip end_metric
+        # read variables
+        num_vars = int(sf.readline().replace("\n", ""))
+        variables = read_variables(sf, num_vars)
+        # read mutexes
+        num_mutexes = int(sf.readline().replace("\n", ""))
+        mutexes = read_mutexes(sf, num_mutexes)
+        # read init state
+        init = read_init_state(sf, num_vars)
+        # read goal
+        goal = read_goal(sf)
+        # read operators
+        num_operators = int(sf.readline().replace("\n", ""))
+        operators = read_operators(sf, num_operators)
+        # read axioms
+        num_axioms = int(sf.readline().replace("\n", ""))
+        axioms = read_axioms(sf, num_axioms)
 
     sas_task = SASTask(variables, mutexes, init, goal, operators, axioms, metric)
     sas_task.validate()

--- a/minimizer/run.py
+++ b/minimizer/run.py
@@ -41,8 +41,8 @@ class Run:
         self.command = command
         self.time_limit = time_limit
         self.memory_limit = memory_limit
-        self.log_on_fail = True if log_output == "on_fail" else False
-        self.log_always = True if log_output == "always" else False
+        self.log_on_fail = log_output == "on_fail"
+        self.log_always = log_output == "always"
 
     def __repr__(self):
         return f'Run(\"{" ".join([os.path.basename(part) for part in self.command])}\")'

--- a/minimizer/run.py
+++ b/minimizer/run.py
@@ -148,9 +148,8 @@ class RunWithInputFile(Run):
             else:
                 raise
 
-        f = open(self.input_file.format(**state), "r")
-        input_text = f.read()
-        f.close()
+        with open(self.input_file.format(**state), "r") as file:
+            input_text = file.read()
 
         out_str, err_str = process.communicate(input=input_text)
 

--- a/minimizer/search.py
+++ b/minimizer/search.py
@@ -2,15 +2,6 @@ from itertools import islice
 from minimizer.tools import SubmissionError, TaskError, PollingError
 
 
-"""
-When performing the search on a Slurm grid, the possibility of
-failure at some point is increased due to the introduced parallelism
-on multiple nodes and an I/O load over the network filesystem. When
-setting *allow_nondeterministic_successor_choice* to ``False``, the
-:func:`search <minimizer.search.search>` function will enforce that
-the search is aborted if a single task fails and no successor from
-an earlier task is accepted.
-"""
 def search(initial_state, successor_generator, evaluator, environment):
     current_state = initial_state
     batch_size = environment.batch_size

--- a/minimizer/search.py
+++ b/minimizer/search.py
@@ -2,6 +2,15 @@ from itertools import islice
 from minimizer.tools import SubmissionError, TaskError, PollingError
 
 
+"""
+When performing the search on a Slurm grid, the possibility of
+failure at some point is increased due to the introduced parallelism
+on multiple nodes and an I/O load over the network filesystem. When
+setting *allow_nondeterministic_successor_choice* to ``False``, the
+:func:`search <minimizer.search.search>` function will enforce that
+the search is aborted if a single task fails and no successor from
+an earlier task is accepted.
+"""
 def search(initial_state, successor_generator, evaluator, environment):
     current_state = initial_state
     batch_size = environment.batch_size


### PR DESCRIPTION
I've implemented several minor changes discussed during the code-walk meetings with @FlorianPommerening and @roeger. They don't change anything about the logic but are concerned with renaming stuff for clarification and other minor things to prettify and clean up the code. Here is a list of the changes:
- Return floating point number when randomly sleeping before submitting jobs to the grid.
- Replace `True if x else False` with `x`.
- Ensure files are closed after reading/writing.
- Rename result files on the grid to `exit_code` and reduce their content to only the exit code without a string that needs to match around it.
- Rename `enforce_order` to `allow_nondeterministic_successor_choice`.